### PR TITLE
Catch errors produced by SweetXml and turn them into error tuple

### DIFF
--- a/lib/gpx_ex/parser.ex
+++ b/lib/gpx_ex/parser.ex
@@ -2,22 +2,27 @@ defmodule GpxEx.Parser do
   import SweetXml
 
   def parse(gpx_document) do
-    tracks =
-      gpx_document
-      |> get_track_elements()
-      |> Enum.map(&build_track/1)
+    try do
+      tracks =
+        gpx_document
+        |> get_track_elements()
+        |> Enum.map(&build_track/1)
 
-    standalone_waypoints =
-      gpx_document
-      |> get_top_level_waypoint_elements()
-      |> Enum.map(&build_waypoint/1)
+      standalone_waypoints =
+        gpx_document
+        |> get_top_level_waypoint_elements()
+        |> Enum.map(&build_waypoint/1)
 
-    routes =
-      gpx_document
-      |> get_route_elements()
-      |> Enum.map(&build_route/1)
+      routes =
+        gpx_document
+        |> get_route_elements()
+        |> Enum.map(&build_route/1)
 
-    {:ok, %GpxEx.Gpx{tracks: tracks, waypoints: standalone_waypoints, routes: routes}}
+      {:ok, %GpxEx.Gpx{tracks: tracks, waypoints: standalone_waypoints, routes: routes}}
+    catch
+      _kind, {:fatal, {xmerl_error, _, _, _}} -> {:error, xmerl_error}
+      _kind, error -> {:error, error}
+    end
   end
 
   defp build_track(track_xml_element) do

--- a/test/gpx_ex_test.exs
+++ b/test/gpx_ex_test.exs
@@ -103,4 +103,31 @@ defmodule GpxExTest do
 
     assert {:ok, expected} == GpxEx.parse(gpx_doc)
   end
+
+  test "gracefully handles unexpected ends to XML" do
+    incomplete = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <gpx version="1.1" creator="Apple Health Export" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+      <metadata>
+        <name>Sample GPX file</name>
+        <desc>Lorem ipsum</desc>
+        <time>2022-04-11T14:08:13Z</time>
+      </metadata>
+      <rte>
+    """
+
+    ExUnit.CaptureLog.capture_log(fn ->
+      assert {:error, :unexpected_end} == GpxEx.parse(incomplete)
+    end)
+  end
+
+  test "gracefully handles missing elements" do
+    missing_elements = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    """
+
+    ExUnit.CaptureLog.capture_log(fn ->
+      assert {:error, :expected_element_start_tag} == GpxEx.parse(missing_elements)
+    end)
+  end
 end


### PR DESCRIPTION
This wraps the parse step in some error handling logic, so that rather than crashing the calling process on parse error, we return `{:error, something}`.